### PR TITLE
_.id = undefined

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -120,7 +120,7 @@
 
         events: {
             'remove-event'(event) {
-                $(this.$els.calendar).fullCalendar('removeEvents', event._id)
+                $(this.$els.calendar).fullCalendar('removeEvents', event.id)
             },
             'rerender-events'(event) {
                 $(this.$els.calendar).fullCalendar('rerenderEvents')


### PR DESCRIPTION
Maybe I am wrong but when I delete an event the documentation wants an id not _.id from an event. When I changed event._id to event.id. I can delete a single event instance.