### PR TITLE
Add emission of event-render events

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -82,10 +82,11 @@
                     events: this.events,
                     eventSources: this.eventSources,
 
-                    eventRender(event, element) {
+                    eventRender(event, element, view) {
                         if (this.sync) {
                             self.events = cal.fullCalendar('clientEvents')
                         }
+                        self.$emit('event-render', event, element, view)
                     },
 
                     eventDestroy(event) {


### PR DESCRIPTION
Adds a vue event that is emitted whenever fullcalendar emits renderEvent, as discussed in https://github.com/CroudSupport/vue-fullcalendar/issues/25