### PR TITLE
Resolves #42

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -99,16 +99,16 @@
                         self.$emit('event-selected', event, jsEvent, view)
                     },
 
-                    eventDrop(event) {
-                        self.$emit('event-drop', event)
+                    eventDrop(event, delta, revertFunc, jsEvent, ui, view) {
+                        self.$emit('event-drop', event, delta, revertFunc, jsEvent, ui, view)
                     },
 
-                    eventResize(event) {
-                        self.$emit('event-resize', event)
+                    eventResize(event, delta, revertFunc, jsEvent, ui, view) {
+                        self.$emit('event-resize', event, delta, revertFunc, jsEvent, ui, view)
                     },
 
                     dayClick(date, jsEvent, view){
-                      self.$emit('day-click', date, jsEvent, view)
+                        self.$emit('day-click', date, jsEvent, view)
                     },
 
                     select(start, end, jsEvent) {
@@ -127,7 +127,11 @@
                 self = this
 
             this.$on('remove-event', (event) => {
-                $(this.$el).fullCalendar('removeEvents', event.id)
+                if(event && event.hasOwnProperty(id)){
+                    $(this.$el).fullCalendar('removeEvents', event.id);
+                }else{
+                    $(this.$el).fullCalendar('removeEvents', event);
+                }
             })
 
             this.$on('rerender-events', () => {

--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -82,11 +82,11 @@
                     events: this.events,
                     eventSources: this.eventSources,
 
-                    eventRender(event, element, view) {
+                    eventRender(...args) {
                         if (this.sync) {
                             self.events = cal.fullCalendar('clientEvents')
                         }
-                        self.$emit('event-render', event, element, view)
+                        self.$emit('event-render', ...args)
                     },
 
                     eventDestroy(event) {
@@ -95,20 +95,20 @@
                         }
                     },
 
-                    eventClick(event, jsEvent, view) {
-                        self.$emit('event-selected', event, jsEvent, view)
+                    eventClick(...args) {
+                        self.$emit('event-selected', ...args)
                     },
 
-                    eventDrop(event, delta, revertFunc, jsEvent, ui, view) {
-                        self.$emit('event-drop', event, delta, revertFunc, jsEvent, ui, view)
+                    eventDrop(...args) {
+                        self.$emit('event-drop', ...args)
                     },
 
-                    eventResize(event, delta, revertFunc, jsEvent, ui, view) {
-                        self.$emit('event-resize', event, delta, revertFunc, jsEvent, ui, view)
+                    eventResize(...args) {
+                        self.$emit('event-resize', ...args)
                     },
 
-                    dayClick(date, jsEvent, view){
-                        self.$emit('day-click', date, jsEvent, view)
+                    dayClick(...args){
+                        self.$emit('day-click', ...args)
                     },
 
                     select(start, end, jsEvent) {


### PR DESCRIPTION
This PR changes the functions [eventDrop](https://fullcalendar.io/docs/event_ui/eventDrop/) and [eventResize](https://fullcalendar.io/docs/event_ui/eventResize/), such that they pass through all parameters that they receive from fullcalendar.
I also changed the  `remove-event` listener function such that it not only allows removal of events by their ID, but also a filter function (for which the parameter name 'event' may be a bit inappropriate then), as described [in the documentation of this function](https://fullcalendar.io/docs/event_data/removeEvents/). This is useful when an event needs to be removed before it has been assigned an ID.