### PR TITLE
import jQuery in the component

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -5,6 +5,7 @@
 <script>
     import defaultsDeep from 'lodash.defaultsdeep'
     import 'fullcalendar'
+    import $ from 'jquery'
 
     export default {
         props: {


### PR DESCRIPTION
refs #52

This enhancement will mean that our users won't need to include jQuery in their project. This shouldn't break for anyone who has already included jQuery, but can we test in our projects before it gets merged into master.

Cheers
Brock