### PR TITLE
Return the result of the function called by fireMethod

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -164,7 +164,7 @@
 
         methods: {
             fireMethod(...options) {
-                $(this.$el).fullCalendar(...options)
+                return $(this.$el).fullCalendar(...options)
             },
         },
 


### PR DESCRIPTION
Returning the result in  fireMethod allows the use of fireMethod('getDate'); etc