### PR TITLE
Fix #99 'rebuild-sources' should use removeEventSources

### DIFF
--- a/components/FullCalendar.vue
+++ b/components/FullCalendar.vue
@@ -154,7 +154,7 @@
             })
 
             this.$on('rebuild-sources', () => {
-                $(this.$el).fullCalendar('removeEvents')
+                $(this.$el).fullCalendar('removeEventSources')
                 this.eventSources.map(event => {
                     $(this.$el).fullCalendar('addEventSource', event)
                 })


### PR DESCRIPTION
Remove all event sources before adding them again when change on eventSources is detected to prevent duplicates