### PR TITLE
Fix fullcalendar version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
     "fullcalendar": "3.10.1",
+    "jquery": "3.4.1",
     "lodash.defaultsdeep": "^4.6.0"
   },
   "devDependencies": {
@@ -41,7 +42,6 @@
     "jest": "^21.2.1",
     "jest-serializer-vue": "^0.3.0",
     "jest-vue": "^0.8.2",
-    "jquery": "^3.2.1",
     "vue": "^2.5.4",
     "vue-template-compiler": "^2.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-full-calendar",
-  "version": "2.8.0",
+  "version": "2.8.1-0",
   "description": "FullCalendar wrapper for vue",
   "main": "index.js",
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/CroudSupport/vue-fullcalendar#readme",
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
-    "fullcalendar": "^3.4.0",
+    "fullcalendar": "3.10.1",
     "lodash.defaultsdeep": "^4.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-full-calendar",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "FullCalendar wrapper for vue",
   "main": "index.js",
   "browserify": {


### PR DESCRIPTION
Fixes the `fullcalendar` and `jquery` version to fix issues in #215 #216 
This has been released as a pre-patch version in `vue-full-calendar@2.8.1-0`